### PR TITLE
Do not require label on end subroutine statement

### DIFF
--- a/scripts/fortran_tools/parse_fortran_file.py
+++ b/scripts/fortran_tools/parse_fortran_file.py
@@ -633,6 +633,7 @@ def parse_scheme_metadata(statements, pobj, spec_name, table_name, run_env):
             seen_contains = seen_contains or is_contains_statement(statement, insub)
             if seen_contains:
                 inpreamble = False
+            # End if
             if asmatch is not None:
                 # We have run off the end of something, hope that is okay
                 # Put this statement back for the caller to deal with
@@ -680,7 +681,7 @@ def parse_scheme_metadata(statements, pobj, spec_name, table_name, run_env):
                 # End if
             elif inpreamble or seen_contains:
                 # Process a preamble statement (use or argument declaration)
-                if esmatch is not None and scheme_name == esmatch.group(1):
+                if esmatch is not None:
                     inpreamble = False
                     seen_contains = False
                     insub = False

--- a/test/capgen_test/temp_calc_adjust.F90
+++ b/test/capgen_test/temp_calc_adjust.F90
@@ -28,12 +28,16 @@ CONTAINS
       integer,            intent(out)   :: errflg
       !----------------------------------------------------------------
 
-      integer :: col_index
+      integer         :: col_index
+      real(kind_phys) :: bar = 1.0_kind_phys
 
       errmsg = ''
       errflg = 0
 
       call temp_calc_adjust_nested_subroutine(temp_calc)
+      if (check_foo()) then
+         call foo(bar)
+      end if
 
    CONTAINS
 
@@ -46,7 +50,17 @@ CONTAINS
 
       END SUBROUTINE temp_calc_adjust_nested_subroutine
 
-   END SUBROUTINE temp_calc_adjust_run
+      SUBROUTINE foo(bar)
+         REAL(kind_phys), intent(inout) :: bar
+         bar = bar + 1.0_kind_phys
+
+      END SUBROUTINE
+
+      logical function check_foo()
+         check_foo = .true.
+      end function check_foo
+
+   END SUBROUTINE
 
    !> \section arg_table_temp_calc_adjust_init  Argument Table
    !! \htmlinclude arg_table_temp_calc_adjust_init.html


### PR DESCRIPTION
I added more test code in temp_calc_adjust.F90 and also made a small change to parse_fortran_file.py (removed an unnecessary check).
I think I have tested all combinations of labeled and unlabeled in `temp_calc_adjust_run`.